### PR TITLE
Added Cat API service, including first call to get list of cat images.

### DIFF
--- a/src/Components/Cats/CatList.test.tsx
+++ b/src/Components/Cats/CatList.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+
+import { getCatImages } from '../../Services/CatAPIService';
+import CatList from './CatList';
+import TEST_CAT_IMAGES from '../../TestData/catImage';
+
+jest.mock('../../Services/CatAPIService.ts');
+const mockGetCatImages: jest.Mocked<any> = getCatImages;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Not Found Page tests', () => {
+  test('Page renders without error.', () => {
+    render(<CatList />);
+
+    expect(screen.queryByText('Your Cats:')).toBeInTheDocument();
+    expect(
+      screen.queryByText('You have no images to display.')
+    ).toBeInTheDocument();
+  });
+
+  test('Display cat images when the API call is successful.', async () => {
+    mockGetCatImages.mockResolvedValueOnce([TEST_CAT_IMAGES, null]);
+    render(<CatList />);
+
+    expect(await screen.findByText('testName')).toBeInTheDocument();
+    expect(screen.queryByText('testName')).toBeInTheDocument();
+  });
+
+  test('Display an error message when the API call fails.', async () => {
+    mockGetCatImages.mockResolvedValueOnce([null, { message: 'test error' }]);
+    render(<CatList />);
+
+    expect(await screen.findByText('test error')).toBeInTheDocument();
+    expect(screen.queryByText('testName')).toBeNull();
+  });
+});

--- a/src/Components/Cats/CatList.tsx
+++ b/src/Components/Cats/CatList.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+import { getCatImages } from '../../Services/CatAPIService';
+import { CatImage } from '../../Types/catImage';
+import CatListView from './CatListView';
+
+const CatList: React.FC = () => {
+  const [catImages, setCatImages] = useState<CatImage[]>([]);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    const fetchImages = async () => {
+      const response = await getCatImages();
+      if (!response) return;
+
+      const [images, error] = response;
+      if (error) setError(error.message);
+      else setCatImages(images || []);
+    };
+
+    fetchImages();
+  }, []);
+
+  return <CatListView images={catImages} error={error} />;
+};
+
+export default CatList;

--- a/src/Components/Cats/CatListView.tsx
+++ b/src/Components/Cats/CatListView.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import { CatImage } from '../../Types/catImage';
+
+type PropsType = {
+  images: CatImage[];
+  error?: string;
+};
+
+const renderCatImage = (image: CatImage) => {
+  return (
+    <div key={image.id} className="item">
+      {image.original_filename}
+    </div>
+  );
+};
+
+const CatList: React.FC<PropsType> = ({ images, error }) => {
+  return (
+    <div className="container">
+      <Typography variant="h2">Your Cats:</Typography>
+      {error && <div className="error">{error}</div>}
+      {images.length > 0 ? (
+        images.map((image) => renderCatImage(image))
+      ) : (
+        <Typography>You have no images to display.</Typography>
+      )}
+    </div>
+  );
+};
+
+export default CatList;

--- a/src/Pages/Cats/CatsListPage.tsx
+++ b/src/Pages/Cats/CatsListPage.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import { PageContent } from '../../Components/Templates/Page';
+import CatList from '../../Components/Cats/CatList';
 
 const CatListPage: React.FC = () => {
   return (
     <PageContent>
-      <h1>Your Cats:</h1>
+      <CatList />
     </PageContent>
   );
 };

--- a/src/Services/CatAPIService.ts
+++ b/src/Services/CatAPIService.ts
@@ -1,0 +1,35 @@
+import { CatImage, CatImageAPIError } from '../Types/catImage';
+
+const CAT_API = 'https://api.thecatapi.com/v1';
+const TOKEN = '423611ae-32ca-4975-8f74-5af272244b62';
+
+const getHeader = (): Headers => {
+  const headers = new Headers();
+
+  headers.append('x-api-key', TOKEN);
+  headers.append('Content-Type', 'application/json');
+
+  return headers;
+};
+
+const http = async <T>(
+  path: string,
+  args: RequestInit
+): Promise<[T | null, CatImageAPIError | null]> => {
+  try {
+    const response = await fetch(new Request(path, args));
+    const data = await response.json();
+    return [data, null];
+  } catch (error) {
+    return [null, error];
+  }
+};
+
+export const getCatImages = async (): Promise<
+  [CatImage[] | null, CatImageAPIError | null]
+> => {
+  return await http<CatImage[]>(`${CAT_API}/images/`, {
+    method: 'get',
+    headers: getHeader(),
+  });
+};

--- a/src/TestData/catImage.ts
+++ b/src/TestData/catImage.ts
@@ -1,0 +1,30 @@
+import { CatImage } from '../Types/catImage';
+
+const TEST_CAT_IMAGES: CatImage[] = [
+  {
+    id: '0',
+    sub_id: '0',
+    url: 'testUrl',
+    original_filename: 'testName',
+    created_at: '2021-01-01T00:00:00Z',
+
+    categories: {
+      id: 0,
+      name: 'testCategory',
+    },
+  },
+  {
+    id: '1',
+    sub_id: '1',
+    url: 'testUrl2',
+    original_filename: 'testName2',
+    created_at: '2021-01-02T00:00:00Z',
+
+    categories: {
+      id: 1,
+      name: 'testCategory2',
+    },
+  },
+];
+
+export default TEST_CAT_IMAGES;

--- a/src/Types/catImage.ts
+++ b/src/Types/catImage.ts
@@ -1,0 +1,18 @@
+export interface CatImage {
+  id: string;
+  url: string;
+  sub_id: string;
+  created_at: string;
+  original_filename: string;
+
+  categories: {
+    id: number;
+    name: string;
+  };
+}
+
+export type CatImageAPIError = {
+  level: string;
+  message: string;
+  status: number;
+};


### PR DESCRIPTION
Updated Cat List page to display the list component. 
  It will call the cat API once, storing the results in local state. Currently, it will just display the original file name. 