### PR TITLE
Added upload-cat-image functionality.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "@types/jest": "^26.0.15",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",

--- a/src/Components/Cats/CatList.test.tsx
+++ b/src/Components/Cats/CatList.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { screen, render, fireEvent } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 
-import { getCatImages } from '../../Services/CatAPIService';
 import CatList from './CatList';
 import TEST_CAT_IMAGES from '../../TestData/catImage';
+import Routes from '../../Layout/Routes';
+import { getCatImages } from '../../Services/CatAPIService';
 
 jest.mock('../../Services/CatAPIService.ts');
 const mockGetCatImages: jest.Mocked<any> = getCatImages;
@@ -12,8 +15,8 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-describe('Not Found Page tests', () => {
-  test('Page renders without error.', () => {
+describe('Cat List component tests', () => {
+  test('renders without error.', () => {
     render(<CatList />);
 
     expect(screen.queryByText('Your Cats:')).toBeInTheDocument();
@@ -36,5 +39,18 @@ describe('Not Found Page tests', () => {
 
     expect(await screen.findByText('test error')).toBeInTheDocument();
     expect(screen.queryByText('testName')).toBeNull();
+  });
+
+  test('Navigates to the upload screen when the new image button is clicked.', () => {
+    const history = createMemoryHistory({ initialEntries: ['/'] });
+    render(
+      <Router history={history}>
+        <CatList />
+      </Router>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    expect(history.location.pathname).toEqual(Routes.Upload);
   });
 });

--- a/src/Components/Cats/CatList.tsx
+++ b/src/Components/Cats/CatList.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import Routes from '../../Layout/Routes';
 
 import { getCatImages } from '../../Services/CatAPIService';
 import { CatImage } from '../../Types/catImage';
@@ -7,6 +9,7 @@ import CatListView from './CatListView';
 const CatList: React.FC = () => {
   const [catImages, setCatImages] = useState<CatImage[]>([]);
   const [error, setError] = useState<string>();
+  const history = useHistory();
 
   useEffect(() => {
     const fetchImages = async () => {
@@ -21,7 +24,11 @@ const CatList: React.FC = () => {
     fetchImages();
   }, []);
 
-  return <CatListView images={catImages} error={error} />;
+  const onNewImage = () => history.push(Routes.Upload);
+
+  return (
+    <CatListView images={catImages} error={error} onNewImage={onNewImage} />
+  );
 };
 
 export default CatList;

--- a/src/Components/Cats/CatListView.tsx
+++ b/src/Components/Cats/CatListView.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
+import AddIcon from '@material-ui/icons/Add';
+
 import { CatImage } from '../../Types/catImage';
 
 type PropsType = {
   images: CatImage[];
+  onNewImage: () => void;
   error?: string;
 };
 
@@ -15,7 +19,7 @@ const renderCatImage = (image: CatImage) => {
   );
 };
 
-const CatList: React.FC<PropsType> = ({ images, error }) => {
+const CatList: React.FC<PropsType> = ({ images, error, onNewImage }) => {
   return (
     <div className="container">
       <Typography variant="h2">Your Cats:</Typography>
@@ -25,6 +29,14 @@ const CatList: React.FC<PropsType> = ({ images, error }) => {
       ) : (
         <Typography>You have no images to display.</Typography>
       )}
+      <Button
+        onClick={onNewImage}
+        variant="contained"
+        color="primary"
+        endIcon={<AddIcon />}
+      >
+        Upload
+      </Button>
     </div>
   );
 };

--- a/src/Components/Cats/UploadCat.test.tsx
+++ b/src/Components/Cats/UploadCat.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
+
+import UploadCat from './UploadCat';
+import { uploadCatImage } from '../../Services/CatAPIService';
+
+jest.mock('../../Services/CatAPIService.ts');
+const mockUploadImage: jest.Mocked<any> = uploadCatImage;
+
+describe('Upload Cat component tests', () => {
+  test('renders without error.', () => {
+    render(<UploadCat />);
+
+    expect(
+      screen.getByRole('button', { name: 'Choose Image' })
+    ).toBeInTheDocument();
+  });
+
+  test('Uploads an image successfully.', async () => {
+    global.URL.createObjectURL = jest
+      .fn()
+      .mockImplementationOnce(() => 'testUrl');
+    mockUploadImage.mockResolvedValueOnce([{}, null]);
+    const testFile = new File(['a test'], 'test.png', { type: 'image/png' });
+
+    render(<UploadCat />);
+
+    const fileInput = screen.getByLabelText('Choose Image');
+    fireEvent.change(fileInput, {
+      target: { files: [testFile] },
+    });
+
+    const uploadImage = screen.queryByAltText('Upload');
+    expect(uploadImage).toBeInTheDocument();
+    expect(uploadImage).toHaveAttribute('src', 'testUrl');
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => expect(mockUploadImage).toHaveBeenCalledTimes(1));
+    expect(mockUploadImage).toHaveBeenCalledWith({
+      file: testFile,
+      sub_id: 'TempUser-4321',
+    });
+
+    expect(screen.queryByAltText('Upload')).toBeNull();
+  });
+
+  test('Display an error when an upload fails.', async () => {
+    global.URL.createObjectURL = jest
+      .fn()
+      .mockImplementationOnce(() => 'testUrl');
+    mockUploadImage.mockResolvedValueOnce([{}, { message: 'test error' }]);
+    const testFile = new File(['a test'], 'test.png', { type: 'image/png' });
+
+    render(<UploadCat />);
+
+    const fileInput = screen.getByLabelText('Choose Image');
+    fireEvent.change(fileInput, {
+      target: { files: [testFile] },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('test error')).toBeInTheDocument()
+    );
+
+    expect(screen.queryByAltText('Upload')).toBeInTheDocument();
+  });
+});

--- a/src/Components/Cats/UploadCat.tsx
+++ b/src/Components/Cats/UploadCat.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { uploadCatImage } from '../../Services/CatAPIService';
+
+import UploadCatView from './UploadCatView';
+
+const UploadCat: React.FC = () => {
+  const [error, setError] = useState<string>();
+
+  const onUpload = async (file: File) => {
+    const response = await uploadCatImage({
+      file,
+      sub_id: 'TempUser-4321',
+    });
+
+    if (!response) return false;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, error] = response;
+
+    if (error) {
+      setError(error.message);
+      return false;
+    }
+
+    return true;
+  };
+
+  return <UploadCatView onUpload={onUpload} error={error} />;
+};
+
+export default UploadCat;

--- a/src/Components/Cats/UploadCatView.tsx
+++ b/src/Components/Cats/UploadCatView.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import CloudUploadIcon from '@material-ui/icons/CloudUpload';
+
+type PropsType = {
+  onUpload: (file: File) => Promise<boolean>;
+  error?: string;
+};
+
+type FileState = {
+  raw: File;
+  url: string;
+};
+
+const useStyles = makeStyles({
+  input: { display: 'none' },
+});
+
+const UploadCatView: React.FC<PropsType> = ({ onUpload, error }) => {
+  const classes = useStyles();
+  const [file, setFile] = useState<FileState>();
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files || e.target.files.length === 0) return;
+
+    setFile({
+      raw: e.target.files[0],
+      url: URL.createObjectURL(e.target.files[0]),
+    });
+  };
+
+  const uploadClick = async () => {
+    if (!file) return;
+
+    const success = await onUpload(file.raw);
+    if (success) setFile(undefined);
+  };
+
+  return (
+    <div className="container">
+      {error && <div className="error">{error}</div>}
+      <input
+        accept="image/*"
+        className={classes.input}
+        id="image-upload-input"
+        type="file"
+        onChange={onChange}
+      />
+      <label htmlFor="image-upload-input">
+        <Button variant="contained" component="span">
+          Choose Image
+        </Button>
+      </label>
+
+      <div>
+        {file && (
+          <>
+            <Typography>{file.raw.name}</Typography>
+            <img src={file.url} alt="Upload" />
+            <Button
+              onClick={uploadClick}
+              variant="contained"
+              startIcon={<CloudUploadIcon />}
+              disabled={!file}
+            >
+              Upload
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UploadCatView;

--- a/src/Pages/Cats/UploadCatPage.tsx
+++ b/src/Pages/Cats/UploadCatPage.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+
+import UploadCat from '../../Components/Cats/UploadCat';
 import { PageContent } from '../../Components/Templates/Page';
 
 const UploadCatPage: React.FC = () => {
   return (
     <PageContent>
-      <h1>Upload Cat:</h1>
+      <UploadCat />
     </PageContent>
   );
 };

--- a/src/Services/CatAPIService.ts
+++ b/src/Services/CatAPIService.ts
@@ -1,14 +1,17 @@
-import { CatImage, CatImageAPIError } from '../Types/catImage';
+import {
+  CatImage,
+  CatImageAPIError,
+  CatImageUploadBody,
+} from '../Types/catImage';
 
 const CAT_API = 'https://api.thecatapi.com/v1';
-const TOKEN = '423611ae-32ca-4975-8f74-5af272244b62';
+const TOKEN = process.env.REACT_APP_CAT_API_TOKEN;
 
 const getHeader = (): Headers => {
+  if (!TOKEN) throw new Error('CAT_API_TOKEN is not set.');
+
   const headers = new Headers();
-
   headers.append('x-api-key', TOKEN);
-  headers.append('Content-Type', 'application/json');
-
   return headers;
 };
 
@@ -31,5 +34,19 @@ export const getCatImages = async (): Promise<
   return await http<CatImage[]>(`${CAT_API}/images/`, {
     method: 'get',
     headers: getHeader(),
+  });
+};
+
+export const uploadCatImage = async (
+  data: CatImageUploadBody
+): Promise<[CatImage[] | null, CatImageAPIError | null]> => {
+  const body = new FormData();
+  body.append('file', data.file);
+  body.append('sub_id', data.sub_id);
+
+  return await http<CatImage[]>(`${CAT_API}/images/upload`, {
+    method: 'post',
+    headers: getHeader(),
+    body,
   });
 };

--- a/src/Types/catImage.ts
+++ b/src/Types/catImage.ts
@@ -11,8 +11,13 @@ export interface CatImage {
   };
 }
 
-export type CatImageAPIError = {
+export interface CatImageAPIError extends Error {
   level: string;
   message: string;
   status: number;
+}
+
+export type CatImageUploadBody = {
+  file: File;
+  sub_id: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,6 +1430,13 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"


### PR DESCRIPTION
This commit adds a button which allows the user to be routed to the upload page from the cat list page.
On the upload page, the user is presented with a number of components that will allow them to upload a cat image.
The user is presented with an error if the upload fails.